### PR TITLE
sketch: use mean of both mates for paired read length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -386,6 +406,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -881,6 +902,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +949,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -1347,7 +1385,7 @@ dependencies = [
  "nalgebra 0.35.0",
  "needletail",
  "predicates",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rayon",
  "regex",
  "scalable_cuckoo_filter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,17 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,15 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -406,7 +386,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -902,17 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,12 +917,6 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -1385,7 +1347,7 @@ dependencies = [
  "nalgebra 0.35.0",
  "needletail",
  "predicates",
- "rand 0.10.2",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "scalable_cuckoo_filter",

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -984,10 +984,9 @@ pub fn sketch_pair_sequences(
                         //moving average of the mean mate length (average of R1
                         //and R2) so asymmetric mate lengths are handled correctly
                         counter += 1.;
-                        let pair_mean_len =
-                            (rec1.seq().len() + rec2.seq().len()) as f64 / 2.0;
-                        mean_read_length = mean_read_length
-                            + (pair_mean_len - mean_read_length) / counter;
+                        let pair_mean_len = (rec1.seq().len() + rec2.seq().len()) as f64 / 2.0;
+                        mean_read_length =
+                            mean_read_length + (pair_mean_len - mean_read_length) / counter;
 
                         for km in temp_vec1.iter() {
                             if dedup_fpr == 0. {
@@ -1143,8 +1142,7 @@ pub fn sketch_interleaved_sequences(
             counter += 1.;
             // average of the two mates so asymmetric mate lengths are handled correctly
             let pair_mean_len = (prev_seq.len() + current_seq.len()) as f64 / 2.0;
-            mean_read_length =
-                mean_read_length + (pair_mean_len - mean_read_length) / counter;
+            mean_read_length = mean_read_length + (pair_mean_len - mean_read_length) / counter;
 
             for km in temp_vec1.iter() {
                 if dedup_fpr == 0. {

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -966,6 +966,10 @@ pub fn sketch_pair_sequences(
 
     let mut mean_read_length: f64 = 0.;
     let mut counter: f64 = 0.;
+    // Separate count of mates folded into mean_read_length: only mates long
+    // enough to emit k-mers (len >= k) are included, so counter (pairs) and
+    // len_counter (k-mer-emitting mates) diverge when a mate is sub-k.
+    let mut len_counter: f64 = 0.;
 
     loop {
         let n1 = reader1.next();
@@ -981,12 +985,19 @@ pub fn sketch_pair_sequences(
                         extract_markers(&rec2.seq(), &mut temp_vec2, c, k);
                         let kmer_pair = pair_kmer(&rec1.seq(), &rec2.seq());
 
-                        //moving average of the mean mate length (average of R1
-                        //and R2) so asymmetric mate lengths are handled correctly
+                        // Moving average over both mates (not just R1) so
+                        // asymmetric mate lengths are handled correctly. Mates
+                        // shorter than k emit no k-mers, so they are excluded to
+                        // avoid biasing the coverage correction and driving
+                        // `read_length - k + 1` non-positive in contain.rs.
                         counter += 1.;
-                        let pair_mean_len = (rec1.seq().len() + rec2.seq().len()) as f64 / 2.0;
-                        mean_read_length =
-                            mean_read_length + (pair_mean_len - mean_read_length) / counter;
+                        for mate_len in [rec1.seq().len(), rec2.seq().len()] {
+                            if mate_len >= k {
+                                len_counter += 1.;
+                                mean_read_length +=
+                                    (mate_len as f64 - mean_read_length) / len_counter;
+                            }
+                        }
 
                         for km in temp_vec1.iter() {
                             if dedup_fpr == 0. {
@@ -1112,6 +1123,9 @@ pub fn sketch_interleaved_sequences(
 
     let mut mean_read_length: f64 = 0.;
     let mut counter: f64 = 0.;
+    // See sketch_pair_sequences: only mates that can emit k-mers (len >= k) are
+    // folded into mean_read_length, so this diverges from counter (pairs).
+    let mut len_counter: f64 = 0.;
     let mut pending: Option<(String, Vec<u8>)> = None;
 
     while let Some(rec_result) = reader.next() {
@@ -1140,9 +1154,14 @@ pub fn sketch_interleaved_sequences(
             let kmer_pair = pair_kmer(&prev_seq, &current_seq);
 
             counter += 1.;
-            // average of the two mates so asymmetric mate lengths are handled correctly
-            let pair_mean_len = (prev_seq.len() + current_seq.len()) as f64 / 2.0;
-            mean_read_length = mean_read_length + (pair_mean_len - mean_read_length) / counter;
+            // Average over both mates so asymmetric mate lengths are handled
+            // correctly; exclude mates shorter than k since they emit no k-mers.
+            for mate_len in [prev_seq.len(), current_seq.len()] {
+                if mate_len >= k {
+                    len_counter += 1.;
+                    mean_read_length += (mate_len as f64 - mean_read_length) / len_counter;
+                }
+            }
 
             for km in temp_vec1.iter() {
                 if dedup_fpr == 0. {

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -981,10 +981,13 @@ pub fn sketch_pair_sequences(
                         extract_markers(&rec2.seq(), &mut temp_vec2, c, k);
                         let kmer_pair = pair_kmer(&rec1.seq(), &rec2.seq());
 
-                        //moving average
+                        //moving average of the mean mate length (average of R1
+                        //and R2) so asymmetric mate lengths are handled correctly
                         counter += 1.;
+                        let pair_mean_len =
+                            (rec1.seq().len() + rec2.seq().len()) as f64 / 2.0;
                         mean_read_length = mean_read_length
-                            + ((rec1.seq().len() as f64) - mean_read_length) / counter;
+                            + (pair_mean_len - mean_read_length) / counter;
 
                         for km in temp_vec1.iter() {
                             if dedup_fpr == 0. {
@@ -1138,8 +1141,10 @@ pub fn sketch_interleaved_sequences(
             let kmer_pair = pair_kmer(&prev_seq, &current_seq);
 
             counter += 1.;
+            // average of the two mates so asymmetric mate lengths are handled correctly
+            let pair_mean_len = (prev_seq.len() + current_seq.len()) as f64 / 2.0;
             mean_read_length =
-                mean_read_length + ((prev_seq.len() as f64) - mean_read_length) / counter;
+                mean_read_length + (pair_mean_len - mean_read_length) / counter;
 
             for km in temp_vec1.iter() {
                 if dedup_fpr == 0. {

--- a/src/sketch.rs
+++ b/src/sketch.rs
@@ -990,6 +990,15 @@ pub fn sketch_pair_sequences(
                         // shorter than k emit no k-mers, so they are excluded to
                         // avoid biasing the coverage correction and driving
                         // `read_length - k + 1` non-positive in contain.rs.
+                        //
+                        // Known limitation: for short-insert libraries whose
+                        // mates overlap, R2's overlapping markers are deduped
+                        // against R1 below, so the full R2 length counted here
+                        // slightly overstates the length backing the k-mer
+                        // observations, mildly inflating the -u / read-count
+                        // estimates. Left as-is: at default c most reads carry
+                        // no marker, so weighting length by surviving markers
+                        // would itself bias the mean toward longer reads.
                         counter += 1.;
                         for mate_len in [rec1.seq().len(), rec2.seq().len()] {
                             if mate_len >= k {
@@ -1156,6 +1165,7 @@ pub fn sketch_interleaved_sequences(
             counter += 1.;
             // Average over both mates so asymmetric mate lengths are handled
             // correctly; exclude mates shorter than k since they emit no k-mers.
+            // Same short-insert overlap limitation as sketch_pair_sequences.
             for mate_len in [prev_seq.len(), current_seq.len()] {
                 if mate_len >= k {
                     len_counter += 1.;

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -617,3 +617,55 @@ fn avx512_seeding_matches_avx2_and_scalar() {
         }
     }
 }
+
+// Paired sketching records mean_read_length as the average of the two mate
+// lengths, not the forward (R1) length alone. With asymmetric mates this is
+// what keeps the coverage correction and --estimate-read-counts unbiased.
+#[test]
+fn paired_mean_read_length_averages_both_mates() {
+    use std::io::Write;
+
+    // Deterministic ACGT sequence of a given length.
+    fn seq(len: usize) -> String {
+        "ACGT".chars().cycle().take(len).collect()
+    }
+    fn write_fastq(path: &std::path::Path, read_len: usize, n: usize) {
+        let mut f = std::fs::File::create(path).unwrap();
+        let s = seq(read_len);
+        let q: String = std::iter::repeat('I').take(read_len).collect();
+        for i in 0..n {
+            writeln!(f, "@read{}\n{}\n+\n{}", i, s, q).unwrap();
+        }
+    }
+
+    let r1_len = 150usize;
+    let r2_len = 100usize;
+    let n_pairs = 8usize;
+
+    let dir = std::env::temp_dir().join(format!("weebill_pair_len_{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let r1 = dir.join("r1.fastq");
+    let r2 = dir.join("r2.fastq");
+    write_fastq(&r1, r1_len, n_pairs);
+    write_fastq(&r2, r2_len, n_pairs);
+
+    let (sketch, meta) = weebill::sketch::sketch_pair_sequences(
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        200,
+        31,
+        None,
+        false,
+        0.,
+    )
+    .expect("paired sketching should succeed");
+
+    // Mean read length is the average of the two mate lengths, and each pair
+    // counts as one read.
+    let expected = (r1_len + r2_len) as f64 / 2.0;
+    assert_eq!(sketch.mean_read_length, expected);
+    assert!(sketch.paired);
+    assert_eq!(meta.num_reads, n_pairs as u64);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/unit_test.rs
+++ b/tests/unit_test.rs
@@ -618,31 +618,28 @@ fn avx512_seeding_matches_avx2_and_scalar() {
     }
 }
 
-// Paired sketching records mean_read_length as the average of the two mate
-// lengths, not the forward (R1) length alone. With asymmetric mates this is
-// what keeps the coverage correction and --estimate-read-counts unbiased.
-#[test]
-fn paired_mean_read_length_averages_both_mates() {
+// Write `n` FASTQ records of a fixed length, using a deterministic ACGT
+// sequence and uniform quality.
+fn write_fastq(path: &std::path::Path, read_len: usize, n: usize) {
     use std::io::Write;
-
-    // Deterministic ACGT sequence of a given length.
-    fn seq(len: usize) -> String {
-        "ACGT".chars().cycle().take(len).collect()
+    let s: String = "ACGT".chars().cycle().take(read_len).collect();
+    let q: String = std::iter::repeat('I').take(read_len).collect();
+    let mut f = std::fs::File::create(path).unwrap();
+    for i in 0..n {
+        writeln!(f, "@read{}\n{}\n+\n{}", i, s, q).unwrap();
     }
-    fn write_fastq(path: &std::path::Path, read_len: usize, n: usize) {
-        let mut f = std::fs::File::create(path).unwrap();
-        let s = seq(read_len);
-        let q: String = std::iter::repeat('I').take(read_len).collect();
-        for i in 0..n {
-            writeln!(f, "@read{}\n{}\n+\n{}", i, s, q).unwrap();
-        }
-    }
+}
 
-    let r1_len = 150usize;
-    let r2_len = 100usize;
-    let n_pairs = 8usize;
-
-    let dir = std::env::temp_dir().join(format!("weebill_pair_len_{}", std::process::id()));
+// Sketch a pair of R1/R2 FASTQ files with the given mate lengths and return the
+// resulting mean_read_length and num_reads. Uses a per-tag temp directory.
+fn sketch_pair_lengths(
+    tag: &str,
+    r1_len: usize,
+    r2_len: usize,
+    n_pairs: usize,
+    k: usize,
+) -> (f64, u64) {
+    let dir = std::env::temp_dir().join(format!("weebill_{}_{}", tag, std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     let r1 = dir.join("r1.fastq");
     let r2 = dir.join("r2.fastq");
@@ -653,19 +650,37 @@ fn paired_mean_read_length_averages_both_mates() {
         r1.to_str().unwrap(),
         r2.to_str().unwrap(),
         200,
-        31,
+        k,
         None,
         false,
         0.,
     )
     .expect("paired sketching should succeed");
-
-    // Mean read length is the average of the two mate lengths, and each pair
-    // counts as one read.
-    let expected = (r1_len + r2_len) as f64 / 2.0;
-    assert_eq!(sketch.mean_read_length, expected);
     assert!(sketch.paired);
-    assert_eq!(meta.num_reads, n_pairs as u64);
-
     let _ = std::fs::remove_dir_all(&dir);
+    (sketch.mean_read_length, meta.num_reads)
+}
+
+// Paired sketching records mean_read_length as the average of the two mate
+// lengths, not the forward (R1) length alone. With asymmetric mates this is
+// what keeps the coverage correction and --estimate-read-counts unbiased.
+#[test]
+fn paired_mean_read_length_averages_both_mates() {
+    let (mean_len, num_reads) = sketch_pair_lengths("pair_len", 150, 100, 8, 31);
+    // Average of the two mate lengths; each pair counts as one read.
+    assert_eq!(mean_len, (150.0 + 100.0) / 2.0);
+    assert_eq!(num_reads, 8);
+}
+
+// A mate shorter than k emits no k-mers, so its length must be excluded from
+// mean_read_length. Otherwise the average could fall to/under k-1 and make the
+// `read_length - k + 1` coverage correction in contain.rs zero/negative.
+#[test]
+fn paired_mean_read_length_excludes_sub_k_mates() {
+    // R1=50 (>= k), R2=10 (< k=31): only R1 is counted, so the mean is 50, not
+    // the naive (50+10)/2 = 30 that would break the coverage correction.
+    let (mean_len, num_reads) = sketch_pair_lengths("pair_subk", 50, 10, 8, 31);
+    assert_eq!(mean_len, 50.0);
+    assert!(mean_len as f64 - 31.0 + 1.0 > 0.0);
+    assert_eq!(num_reads, 8);
 }


### PR DESCRIPTION
## Summary

Paired and interleaved sketching recorded `mean_read_length` from the forward (R1) mate only, while **both** mates contribute k-mers to the coverage estimate. With asymmetric mate lengths this biased two downstream calculations:

- the `estimate_unknown` (`-u`) coverage correction `L / (L - k + 1)`, and
- the `--estimate-read-counts` division `total_bases / mean_read_length`.

This PR feeds the **average of the two mate lengths** into the moving average instead, in both `sketch_pair_sequences` (R1/R2 files) and `sketch_interleaved_sequences`.

## Why this is correct, not just a patch

- **Coverage correction:** the average is the exact aggregate value, since total k-mers over a pair = `(R1 - k + 1) + (R2 - k + 1)` spanning `R1 + R2` bases, giving `avg / (avg - k + 1)`.
- **Read-count division:** because both mates already contribute to `final_est_cov`, dividing by the average mate length recovers the individual-read count regardless of asymmetry (e.g. R1=150, R2=100 → correct 2N; R1-only gave a biased ~1.67N).
- **No regression:** for symmetric mates (R1 == R2) the average equals R1, so standard Illumina data is byte-identical to before.

`counter` still increments once per pair, so `num_reads` and the merge weighting are unchanged.

## Sub-k mates

A mate shorter than `k` emits no k-mers, so folding its length into the average could drive `read_length - k + 1` to zero/negative in `estimate_true_cov`/`estimate_covered_bases` (infinite/negative estimates). Only mates with `len >= k` are folded into the mean (tracked by a separate `len_counter`); a sub-k mate falls back to the k-mer-emitting mate's length.

## Testing

- `paired_mean_read_length_averages_both_mates`: asymmetric pair (R1=150, R2=100) → `mean_read_length == 125`, `num_reads == 8`.
- `paired_mean_read_length_excludes_sub_k_mates`: sub-k mate (R1=50, R2=10, k=31) → `mean_read_length == 50` (not 30).
- Full unit suite passes.

## Known limitations (documented, out of scope)

- **Short-insert overlapping mates:** when mates overlap, R2's overlapping markers are deduped against R1, so counting R2's full length slightly overstates the length backing the k-mer observations and mildly inflates the `-u` / read-count estimates. Not "fixed" because at default `c` most reads carry no marker, so weighting length by surviving markers would itself bias the mean toward longer reads. Documented in both paths.
- **`merge_sketches` weighting:** paired sketches are weighted by pair count rather than individual-read count, slightly biasing the merged `mean_read_length` only when merging an asymmetric paired sketch with a single-end one. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmfaZi26EyEfw4zvBWiL2R