### PR TITLE
test: cover all-empty across single+paired input categories

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1468,6 +1468,44 @@ fn test_sketch_merge_tolerate_empty_inputs() {
         "a failed all-empty non-merge run left stray sketch files: {:?}",
         stray
     );
+
+    // The all-empty check spans input categories: a run whose single-end AND paired-end
+    // inputs are all empty must still fail even with the flag -- the flag only tolerates
+    // empties when some other input has reads, never a wholly empty run. Holds for --merge
+    // (no output file) and non-merge alike.
+    let mixed_merge = format!("{}/mixed_merge", dir);
+    let mut cmd = Command::cargo_bin("weebill").unwrap();
+    cmd.arg("sketch")
+        .arg("--merge")
+        .arg("--tolerate-empty-inputs")
+        .arg("-r")
+        .arg(&empty)
+        .arg("-1")
+        .arg(&empty)
+        .arg("-2")
+        .arg(&empty2)
+        .arg("--compressed-database")
+        .arg(&mixed_merge)
+        .assert()
+        .failure();
+    assert!(
+        !Path::new(&format!("{}.sylspc", mixed_merge)).exists(),
+        "an all-empty single+paired --merge run wrote an output file"
+    );
+
+    let mut cmd = Command::cargo_bin("weebill").unwrap();
+    cmd.arg("sketch")
+        .arg("--tolerate-empty-inputs")
+        .arg("-r")
+        .arg(&empty)
+        .arg("-1")
+        .arg(&empty)
+        .arg("-2")
+        .arg(&empty2)
+        .arg("-d")
+        .arg(format!("{}/mixed_nm", dir))
+        .assert()
+        .failure();
 }
 
 /// Extract the (single) data row's Sample_file (col 1) and Containment_ind (col 12)


### PR DESCRIPTION
Follow-up test that was authored during PR #7 review but landed just after the merge was cut, so it didn't make it into `main`.

Asserts that `sketch --tolerate-empty-inputs` still **fails** (exit 1) a run whose single-end **and** paired-end inputs are all empty — the all-empty guard spans input categories, not just one, so the flag only tolerates empties when some other input actually has reads. Verified for both `--merge` (no output file written) and non-merge modes.

Test-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)